### PR TITLE
Require authentication for robot start/stop API

### DIFF
--- a/src/robot_start_stop.py
+++ b/src/robot_start_stop.py
@@ -7,6 +7,7 @@ import yaml
 blueprint = Blueprint('robot_start_stop', __name__)
 
 @blueprint.route('/start', methods=['POST'])
+@login_required
 def claim_and_start_robot():
     user = request.form['user']
 
@@ -23,6 +24,7 @@ def claim_and_start_robot():
     return jsonify({'status': 'success'})
 
 @blueprint.route('/stop', methods=['POST'])
+@login_required
 def stop_robot():
     try:
         subprocess.check_call('robot stop -f', shell=True)
@@ -32,6 +34,7 @@ def stop_robot():
     return jsonify({'status': 'success'})
 
 @blueprint.route('/check', methods=['GET'])
+@login_required
 def check_robot_claim():
     active_user_file = '/var/lib/robot/active_user.yaml'
 


### PR DESCRIPTION
I haven't tested this yet on the robot! You can hold off on merging this until I test it, if you want.
